### PR TITLE
Remove Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,0 @@
-tasks:
-  - init: |
-      composer install


### PR DESCRIPTION
## Issue

Gitpod no longer exists.

## Solution

Remove Gitpod configuration file to keep repository lean.