### PR TITLE
Update deprecated PHP CS Fixer rule set

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ return (new Config())
         // @see https://mlocati.github.io/php-cs-fixer-configurator
         '@PER-CS' => true,
         '@PhpCsFixer' => true,
-        '@PHP83Migration' => true,
+        '@PHP8x3Migration' => true,
         'concat_space' => ['spacing' => 'one'],
         'multiline_whitespace_before_semicolons' => false,
         'no_short_bool_cast' => true,


### PR DESCRIPTION
## Issue

```shelll
$ composer lint:php
...
Detected deprecations in use (they will stop working in next major release):
- Rule set "@PHP83Migration" is deprecated. Use "@PHP8x3Migration" instead.
```


## Soltution

Replace the deprecated rule set "@PHP83Migration" with the updated "@PHP8x3Migration" in the configuration file.